### PR TITLE
fixes: #SHA-19- ContentLayer ESBuild warnings

### DIFF
--- a/src/__registry__/index.tsx
+++ b/src/__registry__/index.tsx
@@ -208,13 +208,6 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/example/breadcrumb/breadcrumb-popover.tsx")),
       files: ["src/registry/default/example/breadcrumb/breadcrumb-popover.tsx"],
     },
-    "breadcrumb-active": {
-      name: "breadcrumb-active",
-      type: "components:example",
-      registryDependencies: ["breadcrumb"],
-      component: React.lazy(() => import("@/registry/default/example/breadcrumb/breadcrumb-active.tsx")),
-      files: ["src/registry/default/example/breadcrumb/breadcrumb-active.tsx"],
-    },
     "breadcrumb-orientation": {
       name: "breadcrumb-orientation",
       type: "components:example",

--- a/src/registry/components.ts
+++ b/src/registry/components.ts
@@ -182,12 +182,6 @@ const examples: Registry = [
     files: ["example/breadcrumb/breadcrumb-popover.tsx"],
   },
   {
-    name: "breadcrumb-active",
-    type: "components:example",
-    registryDependencies: ["breadcrumb"],
-    files: ["example/breadcrumb/breadcrumb-active.tsx"],
-  },
-  {
     name: "breadcrumb-orientation",
     type: "components:example",
     registryDependencies: ["breadcrumb"],


### PR DESCRIPTION
https://linear.app/shadcn-extension/issue/SHA-19/contentlayer-esbuild-warnings-duplicate-keys

Removes duplicated keys for example: breadcrumb-active