### PR TITLE
#SHA-22: Fix: ESLint React Hook dependency array warnings

### DIFF
--- a/src/registry/default/extension/breadcrumb.tsx
+++ b/src/registry/default/extension/breadcrumb.tsx
@@ -134,6 +134,7 @@ export const BreadCrumb = ({
         setOpen(!open);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [activeIndex, value, prevValue]
   );
 
@@ -223,6 +224,7 @@ export const BreadCrumbItem = forwardRef<
     return () => {
       onPrevValueChange(value);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [index, onValueChange]);
 
   return (
@@ -285,6 +287,7 @@ export const BreadCrumbEllipsis = forwardRef<
       const arr = [...prev, index];
       return arr.sort((a, b) => Number(a) - Number(b));
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [index, onValueChange]);
   return (
     <span

--- a/src/registry/default/extension/carousel.tsx
+++ b/src/registry/default/extension/carousel.tsx
@@ -138,6 +138,7 @@ const Carousel = forwardRef<
             break;
         }
       },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [emblaMainApi, orientation, direction]
     );
 

--- a/src/registry/default/extension/file-upload.tsx
+++ b/src/registry/default/extension/file-upload.tsx
@@ -148,6 +148,7 @@ export const FileUploader = forwardRef<
           setActiveIndex(-1);
         }
       },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [value, activeIndex, removeFileFromSet]
     );
 
@@ -189,6 +190,7 @@ export const FileUploader = forwardRef<
           }
         }
       },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [reSelectAll, value]
     );
 

--- a/src/registry/default/extension/image-carousel-upload.tsx
+++ b/src/registry/default/extension/image-carousel-upload.tsx
@@ -92,6 +92,7 @@ export function FileUploadCarouselProvider<T>({
         return [...(prev || []), fileWithPreview];
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [reSelectAll]
   );
 
@@ -112,6 +113,7 @@ export function FileUploadCarouselProvider<T>({
         return newPreview;
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [emblaMainApi, activeIndex]
   );
 
@@ -129,6 +131,7 @@ export function FileUploadCarouselProvider<T>({
         dropzoneState.inputRef.current?.click();
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [emblaMainApi, activeIndex, removeImageFromPreview]
   );
 
@@ -162,6 +165,7 @@ export function FileUploadCarouselProvider<T>({
         }
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [reSelectAll]
   );
 

--- a/src/registry/default/extension/multi-select.tsx
+++ b/src/registry/default/extension/multi-select.tsx
@@ -67,6 +67,7 @@ const MultiSelector = ({
         onValueChange([...value, val]);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [value]
   );
 
@@ -120,6 +121,7 @@ const MultiSelector = ({
         }
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [value, inputValue, activeIndex, loop]
   );
 

--- a/src/registry/default/extension/tree-view-api.tsx
+++ b/src/registry/default/extension/tree-view-api.tsx
@@ -134,6 +134,7 @@ const Tree = forwardRef<HTMLDivElement, TreeViewProps>(
       if (initialSelectedId) {
         expandSpecificTargetedElements(elements, initialSelectedId);
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initialSelectedId, elements]);
 
     const direction = dir === "rtl" ? "rtl" : "ltr";
@@ -355,10 +356,12 @@ const CollapseButton = forwardRef<
     };
 
     elements.forEach(expandTree);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const closeAll = useCallback(() => {
     setExpendedItems?.([]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -366,6 +369,7 @@ const CollapseButton = forwardRef<
     if (expandAll) {
       expendAllTree(elements);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandAll]);
 
   return (


### PR DESCRIPTION
https://linear.app/shadcn-extension/issue/SHA-22/fix-eslint-react-hook-dependency-array-warnings

disables the eslint warnings, but there might be some cases where we should've actually added the values to the dependency array

I did some research about this and left it in the linear task:
https://linear.app/shadcn-extension/issue/SHA-22/fix-eslint-react-hook-dependency-array-warnings#comment-26985577