### PR TITLE
#SHA-12: fix: breadcrumb hover issue

### DIFF
--- a/content/docs/breadcrumb.mdx
+++ b/content/docs/breadcrumb.mdx
@@ -226,7 +226,7 @@ import { Link } from "next/link";
 
 <ComponentPreview name="breadcrumb-separator" />
 
-### BreadCrumb variants
+### BreadCrumb Variants
 
 By default, the Breadcrumb component uses the `default` variant for each item. You can change the variant by passing the `variant` prop to the `BreadcrumbItem` component.
 

--- a/src/registry/default/example/breadcrumb-demo.tsx
+++ b/src/registry/default/example/breadcrumb-demo.tsx
@@ -19,11 +19,11 @@ const BreadCrumbTest = () => {
       </BreadCrumbItem>
       <BreadCrumbSeparator className="" />
       <BreadCrumbItem className="px-2 h-7" index={1}>
-        Settings
+        <Link href="/">Settings</Link>
       </BreadCrumbItem>
       <BreadCrumbSeparator />
       <BreadCrumbItem className="px-2 h-7" index={2}>
-        Account
+        <Link href="/">Account</Link>
       </BreadCrumbItem>
     </BreadCrumb>
   );

--- a/src/registry/default/example/breadcrumb/breadcrumb-popover.tsx
+++ b/src/registry/default/example/breadcrumb/breadcrumb-popover.tsx
@@ -34,10 +34,10 @@ const BreadCrumbTest = () => {
         </BreadCrumbTrigger>
         <BreadCrumbContent className="flex items-center flex-col p-1 max-w-40">
           <BreadCrumbItem index={3} className="px-2 size-8 w-full">
-            Settings
+            <Link href="/">Settings</Link>
           </BreadCrumbItem>
           <BreadCrumbItem index={4} className="px-2 size-8 w-full">
-            Account
+            <Link href="/">Account</Link>
           </BreadCrumbItem>
         </BreadCrumbContent>
       </BreadCrumbPopover>

--- a/src/registry/default/example/breadcrumb/breadcrumb-separator.tsx
+++ b/src/registry/default/example/breadcrumb/breadcrumb-separator.tsx
@@ -20,13 +20,13 @@ const BreadCrumbTest = () => {
         <Slash className="size-3 -rotate-[30deg]" />
       </BreadCrumbSeparator>
       <BreadCrumbItem className="px-2 h-7" index={1}>
-        Settings
+        <Link href="/">Settings</Link>
       </BreadCrumbItem>
       <BreadCrumbSeparator>
         <Slash className="size-3 -rotate-[30deg]" />
       </BreadCrumbSeparator>
       <BreadCrumbItem className="px-2 h-7" index={2}>
-        Account
+        <Link href="/">Account</Link>
       </BreadCrumbItem>
     </BreadCrumb>
   );

--- a/src/registry/default/example/breadcrumb/breadcrumb-variants.tsx
+++ b/src/registry/default/example/breadcrumb/breadcrumb-variants.tsx
@@ -59,11 +59,11 @@ const BreadCrumbTest = () => {
         </BreadCrumbItem>
         <BreadCrumbSeparator />
         <BreadCrumbItem className="px-2 h-7" index={1}>
-          Settings
+          <Link href="/">Settings</Link>
         </BreadCrumbItem>
         <BreadCrumbSeparator />
         <BreadCrumbItem className="px-2 h-7" index={2}>
-          Account
+          <Link href="/">Account</Link>
         </BreadCrumbItem>
       </BreadCrumb>
       <BreadCrumbVariantPicker variant={variant} setVariant={setVariant} />


### PR DESCRIPTION
This commit fixes #28 
Implemented the fix simply by using the nextjs [Link](https://nextjs.org/docs/app/api-reference/components/link) as children to each of the breadcrumb children. As the first link ("Home") in each breadcrumb example already had a Link component as a child, I implemented the same thing for each fo the additional links (Support and Account) in each of the following examples where they were missing:

```shell
        modified:   src/registry/default/example/breadcrumb-demo.tsx
        modified:   src/registry/default/example/breadcrumb/breadcrumb-popover.tsx
        modified:   src/registry/default/example/breadcrumb/breadcrumb-separator.tsx
        modified:   src/registry/default/example/breadcrumb/breadcrumb-variants.tsx
```

I also capitalized the `V` in the heading for "Breadcrumb Variants". this affected the doc file at:
```shell
modified:   content/docs/breadcrumb.mdx
```