### PR TITLE
fixes: errors hydration errors + re-adds vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,4 @@ yarn-error.log*
 next-env.d.ts
 
 .contentlayer
-.vscode
 tsconfig.tsbuildinfo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,5 +49,6 @@
     "suhelmakkad.shadcn-ui",
     "unifiedjs.vscode-mdx",
     "usernamehw.errorlens"
-  ]
+  ],
+  "cSpell.words": ["nums", "timescape"]
 }

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -21,6 +21,7 @@ export const SearchPopOver = () => {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [mounted, setMounted] = useState(false);
   const isMac = isMacOs();
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
@@ -50,11 +51,18 @@ export const SearchPopOver = () => {
   const handleSearch = (query: string) => {
     setQuery(query);
   };
+
   useEffect(() => {
     if (!isOpen) setQuery("");
   }, [isOpen]);
 
-  return (
+  useEffect(() => {
+    if (mounted) return;
+    setMounted(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return mounted ? (
     <>
       <Button
         variant="ghost"
@@ -87,7 +95,7 @@ export const SearchPopOver = () => {
             />
             <CommandList>
               <CommandEmpty className={cn("py-6 text-center text-sm")}>
-                No products found.
+                No documents found.
               </CommandEmpty>
               <CommandGroup
                 className="capitalize block md:hidden"
@@ -140,5 +148,5 @@ export const SearchPopOver = () => {
         </CredenzaContent>
       </Credenza>
     </>
-  );
+  ) : null;
 };


### PR DESCRIPTION
Implements several small fixes:
- [x] fixes hydration error warning caused by the command component's button element where the icon was rendering a placeholder on the server (`Crtl`) and the actual icon on the client. I used a useMount pattern to make sure the component doesn't load on the server. 
- [x] removed `.vscode/settings.son` from .gitignore - this allows us to share linting configurations amongst developers allowing us to ensure better code quality. I also added a few extensions to the recommended extensions array in the file Most of the extensions are related to better handling of errors, typescript, and linting. Just to clarify these are only recommended they will not self install the user still has to manually accept and install them if they want to. 

![image](https://github.com/BelkacemYerfa/shadcn-extension/assets/1086269/790701cb-60ca-4514-8c8f-53f3e1be3214)
![image](https://github.com/BelkacemYerfa/shadcn-extension/assets/1086269/dc533aac-6b7d-4279-9971-4fd36d9045d8)
![image](https://github.com/BelkacemYerfa/shadcn-extension/assets/1086269/ad3a9b67-7ead-4c22-8e21-7f27a9b42f1f)
