### PR TITLE
workflow: integrate stale PR auto closing bot

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,12 @@
+name: Close Stale Issues
+
+on:
+    schedule:
+        - cron: '0 0 * * *' # Runs at midnight every day
+
+jobs:
+    close-stale-issues:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Close Stale Issues
+              uses: actions/stale@v9.0.0


### PR DESCRIPTION
## Description

This PR introduces a workflow to automatically manage and close stale pull requests in our repository. 

By integrating a stale [PR auto-closing bot](https://github.com/marketplace/actions/close-stale-issues), I aim to keep our repository clean and up-to-date, ensuring that inactive and outdated pull requests do not accumulate over time. 

This bot will identify pull requests that have not been updated or commented on for a specified period and mark them as stale. 

If there is no further activity within a certain period after being marked stale, the bot will automatically close the pull request.

## Key Features

- [x] Identification of Stale PRs: The bot will monitor pull requests and mark those with no activity for a predefined duration as stale.


- [x] Notification: When a PR is marked as stale, a comment will be added to notify the contributors about the pending closure due to inactivity.


- [x] Grace Period: Contributors will have a grace period to update or comment on the stale PR before it is closed automatically.
Automatic Closure: If no activity occurs within the grace period, the bot will close the stale PR to maintain repository hygiene.

## Additional

This is just the default configuration. For advanced usage you can find the documentation [here.](https://github.com/marketplace/actions/close-stale-issues#usage).