### PR TITLE
Add `use-resize-observer` to dependencies to install for treeview.

### DIFF
--- a/content/docs/tree-view.mdx
+++ b/content/docs/tree-view.mdx
@@ -29,7 +29,7 @@ links:
 <Step>Install the following dependencies:</Step>
 
 ```bash
-npm install @radix-ui/react-accordion
+npm install @radix-ui/react-accordion use-resize-observer
 npx shadcn-ui@latest add scroll-area
 ```
 


### PR DESCRIPTION
add `use-resize-observer` to dependencies to install. this package is missing, when installing the component manually.