### PR TITLE
fix: tags-input typing lag

### DIFF
--- a/apps/extension/src/registry/default/extension/tags-input.tsx
+++ b/apps/extension/src/registry/default/extension/tags-input.tsx
@@ -102,7 +102,6 @@ export const TagsInput = React.forwardRef<HTMLDivElement, TagsInputProps>(
 
     const handleSelect = React.useCallback(
       (e: React.SyntheticEvent<HTMLInputElement>) => {
-        e.preventDefault();
         const target = e.currentTarget;
         const selection = target.value.substring(
           target.selectionStart ?? 0,


### PR DESCRIPTION
The prevent default inside the handleSelect function gets triggered every time the text changes and blocks the typing flow, which results in missing keys while typing

Is this check necessary?


Before:

https://github.com/user-attachments/assets/ee0e5ac7-44b9-4a5c-b8a9-14082bcc5962



After:

https://github.com/user-attachments/assets/7eab6037-8756-429c-92c6-c4fcb9c63e72

