### PR TITLE
Datetime Picker: Fix default options overriding value on mount.

### DIFF
--- a/apps/extension/src/registry/default/extension/datetime-picker.tsx
+++ b/apps/extension/src/registry/default/extension/datetime-picker.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { forwardRef, useCallback, useState } from "react";
+import React, { forwardRef, useCallback } from "react";
 import { useTimescape, type Options } from "timescape/react";
 
 import { Input } from "@/components/ui/input";
@@ -136,7 +136,7 @@ const DEFAULT_TS_OPTIONS = {
 export const DatetimePicker = forwardRef<HTMLDivElement, DateTimeInput>(
   (
     {
-      value = new Date(),
+      value,
       format = DEFAULTS,
       placeholders,
       dtOptions = DEFAULT_TS_OPTIONS,
@@ -152,9 +152,9 @@ export const DatetimePicker = forwardRef<HTMLDivElement, DateTimeInput>(
       [onChange],
     );
     const timescape = useTimescape({
-      date: value,
-      onChangeDate: handleDateChange,
       ...dtOptions,
+      ...(value && { date: value }),
+      onChangeDate: handleDateChange,
     });
     return (
       <DatetimeGrid


### PR DESCRIPTION
- When a value is passed up-front, it should take a precedence over default options. 
  - In the current `master` the passed-in value prop is ignored - or rather overriden by default options - even when the user does not declare the `dtOptions`, it gets its default value from `DEFAULT_TS_OPTIONS`.
- Minor: Additionally removing unused `useState` import