### PR TITLE
feat(datetime-input): added support for disabling specific dates in 

### DIFF
--- a/apps/extension/content/docs/smart-datetime-input.mdx
+++ b/apps/extension/content/docs/smart-datetime-input.mdx
@@ -108,9 +108,9 @@ The SmartDatetimeInput component accepts the following props:
     {
       prop: {
         value: "disabled",
-        description: "Used to diable the input",
+        description: "A boolean to disable the input entirely, or a matcher function that takes a Date and returns a boolea--used to disable specific dates",
       },
-      type: { value: ["boolean"] },
+      type: { value: ["boolean | ((date: Date) => boolean)"] },
       defaultValue: { value: [`false`] },
     },
   ]}
@@ -128,6 +128,7 @@ import { SmartDateTimeInput } from "@/components/extension/smart-date-time-input
   value={Date.now()}
   onChange={(e) => setValue(e.target.value)}
   placeholder="e.g. tomorrow at 3pm"
+  disabled={(date) => date < new Date()}
 />
 ```
 
@@ -156,6 +157,7 @@ const SmartDateTimeForm = ()=>{
               value={field.value}
               onChange={field.onChange}
               placeholder="e.g. tomorrow at 3pm"
+              disabled={(date) => date < new Date()}
             />
             {...}
           )} />

--- a/apps/extension/content/docs/smart-datetime-input.mdx
+++ b/apps/extension/content/docs/smart-datetime-input.mdx
@@ -108,7 +108,7 @@ The SmartDatetimeInput component accepts the following props:
     {
       prop: {
         value: "disabled",
-        description: "A boolean to disable the input entirely, or a matcher function that takes a Date and returns a boolea--used to disable specific dates",
+        description: "A boolean to disable the input entirely, or a matcher function that takes a Date and returns a boolean--used to disable specific dates",
       },
       type: { value: ["boolean | ((date: Date) => boolean)"] },
       defaultValue: { value: [`false`] },

--- a/apps/extension/src/registry/default/example/smart-datetime-input-demo.tsx
+++ b/apps/extension/src/registry/default/example/smart-datetime-input-demo.tsx
@@ -1,7 +1,7 @@
 import { SmartDatetimeInput } from "@/registry/default/extension/smart-datetime-input";
 
 const SmartDateTimeInputDemo = () => {
-  return <SmartDatetimeInput onValueChange={console.log} />;
+  return <SmartDatetimeInput onValueChange={console.log} disabled={(date) => date < new Date()} />;
 };
 
 export default SmartDateTimeInputDemo;

--- a/apps/extension/src/registry/default/extension/smart-datetime-input.tsx
+++ b/apps/extension/src/registry/default/extension/smart-datetime-input.tsx
@@ -52,6 +52,29 @@ export const getDateTimeLocal = (timestamp?: Date): string => {
 };
 
 /**
+ * Returns the earliest date (starting with today) that is not disabled by the matcher.
+ * If no dates are `disabled`, we default to new Date().
+ * 
+ * @param disabled - A boolean disabling the entire input, or a matcher function for valid dates.
+ * @returns A `Date` object representing the earliest valid date.
+ */
+const getValidBaseDate = (
+  disabled?: boolean | ((date: Date) => boolean)
+): Date => {
+  if (typeof disabled !== "function") return new Date();
+  let potential = new Date();
+  const MAX_DAYS = 365;
+  for (let i = 0; i < MAX_DAYS; i++) {
+    if (!disabled(potential)) {
+      return potential;
+    }
+    potential = new Date(potential.getTime());
+    potential.setDate(potential.getDate() + 1);
+  }
+  return new Date();
+};
+
+/**
  * Formats a given date and time object or string into a human-readable string representation.
  * "MMM D, YYYY h:mm A" (e.g. "Jan 1, 2023 12:00 PM").
  *
@@ -86,6 +109,7 @@ const DEFAULT_SIZE = 96;
 interface SmartDatetimeInputProps {
   value?: Date;
   onValueChange: (date: Date) => void;
+  disabled?: boolean | ((date: Date) => boolean);
 }
 
 interface SmartDatetimeInputContextProps extends SmartDatetimeInputProps {
@@ -110,9 +134,9 @@ export const SmartDatetimeInput = React.forwardRef<
   HTMLInputElement,
   Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
-    "type" | "ref" | "value" | "defaultValue" | "onBlur"
+    "disabled" | "type" | "ref" | "value" | "defaultValue" | "onBlur"
   > &
-    SmartDatetimeInputProps
+  SmartDatetimeInputProps
 >(({ className, value, onValueChange, placeholder, disabled }, ref) => {
   // ? refactor to be only used with controlled input
   /*  const [dateTime, setDateTime] = React.useState<Date | undefined>(
@@ -127,7 +151,7 @@ export const SmartDatetimeInput = React.forwardRef<
 
   return (
     <SmartDatetimeInputContext.Provider
-      value={{ value, onValueChange, Time, onTimeChange }}
+      value={{ value, onValueChange, Time, onTimeChange, disabled }}
     >
       <div className="flex items-center justify-center">
         <div
@@ -138,10 +162,10 @@ export const SmartDatetimeInput = React.forwardRef<
             className,
           )}
         >
-          <DateTimeLocalInput />
+          <DateTimeLocalInput disabled={disabled} />
           <NaturalLanguageInput
             placeholder={placeholder}
-            disabled={disabled}
+            disabled={typeof disabled === "boolean" ? disabled : false}
             ref={ref}
           />
         </div>
@@ -155,7 +179,7 @@ SmartDatetimeInput.displayName = "DatetimeInput";
 // Make it a standalone component
 
 const TimePicker = () => {
-  const { value, onValueChange, Time, onTimeChange } = useSmartDateInput();
+  const { value, onValueChange, Time, onTimeChange, disabled } = useSmartDateInput();
   const [activeIndex, setActiveIndex] = React.useState(-1);
   const timestamp = 15;
 
@@ -163,7 +187,8 @@ const TimePicker = () => {
     (time: string, hour: number, partStamp: number) => {
       onTimeChange(time);
 
-      const newVal = parseDateTime(value ?? new Date());
+      const base = value ? new Date(value) : getValidBaseDate(disabled);
+      const newVal = parseDateTime(base);
 
       if (!newVal) return;
 
@@ -346,6 +371,34 @@ const TimePicker = () => {
             const PM_AM = i >= 12 ? "PM" : "AM";
             const formatIndex = i > 12 ? i % 12 : i === 0 || i === 12 ? 12 : i;
             return Array.from({ length: 4 }).map((_, part) => {
+              // Create a candidate date using the current value's date if available or today's date.
+              const baseDate = value && !disabled ? new Date(value) : getValidBaseDate(disabled);
+              const candidateDate = new Date(
+                baseDate.getFullYear(),
+                baseDate.getMonth(),
+                baseDate.getDate(),
+                i,
+                part === 0 ? 0 : timestamp * part,
+                0,
+                0,
+              );
+              // Use the matcher if provided to decide if this candidate should be disabled.
+              let candidateDisabled = typeof disabled === "function" ? disabled(candidateDate) : false;
+
+              // Additional check: if the candidate is for today and its time is past, disable it.
+              const now = new Date();
+              if (
+                !candidateDisabled &&
+                candidateDate.getFullYear() === now.getFullYear() &&
+                candidateDate.getMonth() === now.getMonth() &&
+                candidateDate.getDate() === now.getDate() &&
+                candidateDate < now
+              ) {
+                candidateDisabled = true;
+              }
+
+              if (candidateDisabled) return null;
+
               const diff = Math.abs(part * timestamp - currentTime.minutes);
 
               const trueIndex = i * 4 + part;
@@ -402,7 +455,7 @@ const NaturalLanguageInput = React.forwardRef<
     disabled?: boolean;
   }
 >(({ placeholder, ...props }, ref) => {
-  const { value, onValueChange, Time, onTimeChange } = useSmartDateInput();
+  const { value, onValueChange, Time, onTimeChange, disabled } = useSmartDateInput();
 
   const _placeholder = placeholder ?? 'e.g. "tomorrow at 5pm" or "in 2 hours"';
 
@@ -422,6 +475,11 @@ const NaturalLanguageInput = React.forwardRef<
       // parse the date string when the input field loses focus
       const parsedDateTime = parseDateTime(e.currentTarget.value);
       if (parsedDateTime) {
+        // If a matcher function was passed, prevent selecting a disabled (past) date
+        if (disabled && typeof disabled != "boolean" && disabled(parsedDateTime)) {
+          // Invalid input--time already passed
+          return;
+        }
         const PM_AM = parsedDateTime.getHours() >= 12 ? "PM" : "AM";
         //fix the time format for this value
 
@@ -448,6 +506,9 @@ const NaturalLanguageInput = React.forwardRef<
         case "Enter":
           const parsedDateTime = parseDateTime(e.currentTarget.value);
           if (parsedDateTime) {
+            if (disabled && typeof disabled != "boolean" && disabled(parsedDateTime)) {
+              return;
+            }
             const PM_AM = parsedDateTime.getHours() >= 12 ? "PM" : "AM";
             //fix the time format for this value
 
@@ -487,10 +548,11 @@ const NaturalLanguageInput = React.forwardRef<
 
 NaturalLanguageInput.displayName = "NaturalLanguageInput";
 
-type DateTimeLocalInputProps = {} & CalendarProps;
+type DateTimeLocalInputProps = { disabled?: boolean | ((date: Date) => boolean) } & CalendarProps;
 
 const DateTimeLocalInput = ({
   className,
+  disabled,
   ...props
 }: DateTimeLocalInputProps) => {
   const { value, onValueChange, Time } = useSmartDateInput();
@@ -502,6 +564,11 @@ const DateTimeLocalInput = ({
       m: ActiveModifiers,
       e: React.MouseEvent,
     ) => {
+      // if fully disabled, do nothing
+      if (typeof disabled === "boolean" && disabled) return;
+      // if disabled is a matcher function and selected date should be disabled, do nothing
+      if (typeof disabled === "function" && disabled(selectedDate)) return;
+
       const parsedDateTime = parseDateTime(selectedDate);
 
       if (parsedDateTime) {
@@ -519,6 +586,7 @@ const DateTimeLocalInput = ({
     <Popover>
       <PopoverTrigger asChild>
         <Button
+          disabled={typeof disabled === "boolean" ? disabled : false}
           variant={"outline"}
           size={"icon"}
           className={cn(
@@ -533,6 +601,7 @@ const DateTimeLocalInput = ({
       <PopoverContent className="w-auto p-0" sideOffset={8}>
         <div className="flex gap-1">
           <Calendar
+            disabled={disabled}
             {...props}
             id={"calendar"}
             className={cn("peer flex justify-end", inputBase, className)}


### PR DESCRIPTION
Wanted to contribute some code I wrote while working on project using this component. I wanted to disable dates like shadcn's Calendar component supports, but I was surprised this wasn't supported out of the box,. Now you can disable specific dates using a matcher function.

Changes:

- Added a flexible and optional prop that accepts either:
  - A boolean to disable the entire input
  - A matcher function `(date: Date) => boolean` to selectively disable dates. This works the same way as the normal shadcn Calendar.

This makes the component much more practical for real-world use cases like preventing selection of past dates or blocking out holidays/weekends.