### PR TITLE
fix(tags-input): prevent Enter key action during composition

### DIFF
--- a/apps/extension/src/registry/default/extension/tags-input.tsx
+++ b/apps/extension/src/registry/default/extension/tags-input.tsx
@@ -216,6 +216,7 @@ export const TagsInput = React.forwardRef<HTMLDivElement, TagsInputProps>(
             break;
 
           case "Enter":
+            if (e.nativeEvent.isComposing) return;
             if (inputValue.trim() !== "") {
               e.preventDefault();
               onValueChangeHandler(inputValue);


### PR DESCRIPTION
# Fix IME Composition Event Handling in TagsInput Component

## Changes
- Added IME composition check before handling Enter key event
- Prevents tag addition during IME composition state

## Problem Solved
- Fixed issue where pressing Enter during IME composition would incorrectly add tags
- Improved user experience for IME input methods (Korean, Japanese, Chinese)

## ScreenShot

|Before|After|
|------|------|
|<img width="167" alt="image" src="https://github.com/user-attachments/assets/86df70c6-a219-4970-9dcd-fe99294ef110" />|<img width="101" alt="image" src="https://github.com/user-attachments/assets/01a44c8b-7299-431e-8b45-fe652b934ec0" />|



